### PR TITLE
FEAT #55770: l10n_ve_rate

### DIFF
--- a/l10n_ve_rate/__manifest__.py
+++ b/l10n_ve_rate/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Technical",
-    "version": "17.0.0.0.2",
+    "version": "17.0.0.0.3",
     # any module necessary for this one to work correctly
     "depends": ["base", "l10n_ve_base"],
     "data": [

--- a/l10n_ve_rate/i18n/es_VE.po
+++ b/l10n_ve_rate/i18n/es_VE.po
@@ -4,10 +4,10 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 17.0+e-20250321\n"
+"Project-Id-Version: Odoo Server 17.0+e-20250728\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-27 15:53+0000\n"
-"PO-Revision-Date: 2025-03-27 15:53+0000\n"
+"POT-Creation-Date: 2025-08-14 13:14+0000\n"
+"PO-Revision-Date: 2025-08-14 13:14+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -75,6 +75,17 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:l10n_ve_rate.res_config_settings_l10n_ve_rate
 msgid "Set foreign currency"
 msgstr "Establecer moneda alterna"
+
+#. module: l10n_ve_rate
+#. odoo-python
+#: code:addons/l10n_ve_rate/models/res_config_settings.py:0
+#, python-format
+msgid ""
+"The company currency must be in bolivars. Please set the currency to Bolivar"
+" (VEF)."
+msgstr ""
+"La moneda base debe ser en bolívar. Por favor, configure la moneda en Bolívares"
+" (VEF)."
 
 #. module: l10n_ve_rate
 #. odoo-python

--- a/l10n_ve_rate/models/res_config_settings.py
+++ b/l10n_ve_rate/models/res_config_settings.py
@@ -11,6 +11,13 @@ class ResConfigSettings(models.TransientModel):
         default=lambda self: self.env.company,
     )
 
+    currency_id = fields.Many2one(
+        "res.currency",
+        string="Currency",
+        required=True,
+        default=lambda self: self.env.ref("base.VEF").id,
+    )
+
     currency_foreign_id = fields.Many2one(
         "res.currency",
         string="Currency Foreign",
@@ -35,4 +42,13 @@ class ResConfigSettings(models.TransientModel):
             if "currency_id" in rec._fields and rec.currency_id == rec.currency_foreign_id:
                 raise UserError(
                     _("The currency foreign must be different from the currency of the company")
+                )
+
+    @api.constrains("currency_id")
+    def _check_currency_id(self):
+        self = self.with_company(self.company_id)
+        for rec in self:
+            if "currency_id" in rec._fields and rec.currency_id != self.env.ref("base.VEF"):
+                raise UserError(
+                    _("The company currency must be in bolivars. Please set the currency to Bolivar (VEF).")
                 )

--- a/l10n_ve_rate/tests/__init__.py
+++ b/l10n_ve_rate/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_config_settings

--- a/l10n_ve_rate/tests/test_res_config_settings.py
+++ b/l10n_ve_rate/tests/test_res_config_settings.py
@@ -1,0 +1,42 @@
+from odoo.exceptions import UserError
+from odoo import fields, Command
+from odoo.tests import TransactionCase, tagged
+from unittest.mock import patch, MagicMock
+from datetime import datetime, timedelta
+import logging
+
+_logger = logging.getLogger(__name__)
+
+@tagged("post_install", "-at_install", "l10n_ve_rate") 
+class TestResConfigSettings(TransactionCase):
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+
+    def test_01_default_currency_id_is_vef(self):
+        config = self.env["res.config.settings"].new({})
+        self.assertEqual(config.currency_id, self.currency_vef, "The default base currency must be VEF")
+        _logger.info("test_01_default_currency_id_is_vef --- successfully.")
+
+    def test_02_currency_foreign_id_equal_currency_id_raises(self):
+        config = self.env["res.config.settings"].new({
+            "company_id": self.company.id,
+            "currency_id": self.currency_usd.id,
+        })
+        
+        with self.assertRaises(UserError) as e:
+            config._check_currency_id()
+        _logger.info("Expected error: %s", e.exception)
+
+        exception = "The company currency must be in bolivars. Please set the currency to Bolivar (VEF)."
+
+        self.assertEqual(
+            str(e.exception),
+            exception,
+            f"The error message should indicate that: {exception}",
+        )
+
+        _logger.info("test_02_currency_foreign_id_equal_currency_id_raises --- successfully.")


### PR DESCRIPTION
Problema: Se requiere que integra 3.0 solo puede ser base bs

Solución: Colocar VEF como moneda de forma predeterminada y que no se pueda cambiar a otra moneda.

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=55770&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []