### PR TITLE
FEAT #55769: l10n_ve_accountant

### DIFF
--- a/l10n_ve_accountant/__manifest__.py
+++ b/l10n_ve_accountant/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://binauraldev.com/",
     "category": "Accounting/Localizations/Account Chart",
-    "version": "17.0.0.0.13",
+    "version": "17.0.0.0.14",
     "depends": [
         "base",
         "web",

--- a/l10n_ve_accountant/i18n/es_VE.po
+++ b/l10n_ve_accountant/i18n/es_VE.po
@@ -1155,13 +1155,6 @@ msgstr "Solo puedes registrar pagos para una tasa alterna a la vez."
 
 #. module: l10n_ve_accountant
 #. odoo-python
-#: code:addons/l10n_ve_accountant/models/account_move.py:0
-#, python-format
-msgid "You cannot place a currency other than the base of the system."
-msgstr "No puede colocar una moneda que no sea la base del sistema."
-
-#. module: l10n_ve_accountant
-#. odoo-python
 #: code:addons/l10n_ve_accountant/models/account_journal.py:0
 #, python-format
 msgid "You do not have permissions to create/update a journal with this type."

--- a/l10n_ve_accountant/models/account_move.py
+++ b/l10n_ve_accountant/models/account_move.py
@@ -360,14 +360,6 @@ class AccountMove(models.Model):
                 ):
                     raise ValidationError(_("This product must have only one tax."))
 
-    @api.constrains("currency_id")
-    def _check_currency_id(self):
-        for move in self.filtered(lambda m: m.is_invoice(include_receipts=True)):
-            if move.currency_id.id != self.env.company.currency_id.id:
-                raise ValidationError(
-                    _("You cannot place a currency other than the base of the system.")
-                )
-
     def legacy_compute_line_ids_foreign_debit_and_credit(self):
         """
         This method is used to compute the foreign debit and foreign credit of the line_ids field

--- a/l10n_ve_accountant/tests/__init__.py
+++ b/l10n_ve_accountant/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_account_move

--- a/l10n_ve_accountant/tests/test_account_move.py
+++ b/l10n_ve_accountant/tests/test_account_move.py
@@ -1,0 +1,145 @@
+import logging
+import datetime
+from odoo.tests import TransactionCase, tagged
+from odoo import fields, Command
+from odoo.exceptions import UserError, ValidationError
+
+_logger = logging.getLogger(__name__)
+
+@tagged("post_install", "-at_install", "l10n_ve_accountant")
+class TestAccountMove(TransactionCase):
+
+    def setUp(self):
+        super(TestAccountMove, self).setUp()
+        self.currency_usd = self.env.ref("base.USD")
+        self.currency_vef = self.env.ref("base.VEF")
+        self.company = self.env.ref("base.main_company")
+        self.company.write(
+            {
+                "currency_id": self.currency_vef.id,
+                "currency_foreign_id": self.currency_usd.id,
+            }
+        )
+
+        self.tax_iva16 = self.env['account.tax'].create({
+            'name': 'IVA 16%',
+            'amount': 16,
+            'amount_type': 'percent',
+            'type_tax_use': 'sale',
+        })
+
+        self.product = self.env['product.product'].create({
+            'name': 'Producto Prueba',
+            'type': 'service',
+            'list_price': 100,
+            'barcode': '123456789',
+            'taxes_id': [(6, 0, [self.tax_iva16.id])],
+        })
+        
+        self.partner_a = self.env['res.partner'].create({
+            'name': 'Test Partner A',
+            'customer_rank': 1,
+        })
+        
+        self.company_data = {
+            'company': self.env['res.company'].create({
+                'name': 'Test Company',
+                'currency_id': self.env.ref('base.VEF').id,
+            }),
+        }
+        sequence = self.env['ir.sequence'].create({
+            'name': 'Secuencia Factura',
+            'code': 'account.move',
+            'prefix': 'INV/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+        refund_sequence = self.env['ir.sequence'].create({
+            'name': 'nota de credito',
+            'code': '',
+            'prefix': 'NC/',
+            'padding': 8,
+            "number_next_actual": 2,
+        })
+
+        self.journal = self.env['account.journal'].create({
+            'name': 'Diario de Ventas',
+            'code': 'VEN',
+            'type': 'sale',
+            'company_id': self.env.company.id,
+        })
+
+    def _create_invoice(
+            self, 
+            products, 
+            move_type="out_invoice", 
+            reversed_entry_id=None, 
+            debit_origin_id=None, 
+            ref = "Test Invoice",
+            foreign_rate=38,
+            foreign_inverse_rate=38,
+            invoice_date=None
+        ):
+        """Helper function to create an invoice with given parameters.
+        Args:
+            products (list): List of dictionaries with product details.
+            foreign_rate (float): Foreign exchange rate.
+            foreign_inverse_rate (float): Inverse foreign exchange rate.
+        """
+        invoice_lines = [
+            Command.create(
+                {
+                    "product_id": product["product_id"],
+                    "quantity": product.get("quantity", 1),
+                    "price_unit": product["price_unit"],
+                    "tax_ids": product.get("tax_ids", []),
+                }
+            )
+            for product in products
+        ]
+
+        invoice_vals = {
+            "move_type": move_type,
+            "partner_id": self.partner_a.id,
+            "foreign_currency_id": self.currency_usd.id,
+            "currency_id": self.currency_vef.id,
+            "state": "draft",
+            "foreign_rate": foreign_rate,
+            "foreign_inverse_rate": foreign_inverse_rate,
+            "manually_set_rate": True,
+            "invoice_line_ids": invoice_lines,
+            "invoice_date": fields.Date.today(),
+            "journal_id": self.journal.id,
+        }
+
+        # Solo para notas de crédito
+        if move_type == "out_refund" and reversed_entry_id:
+            invoice_vals["reversed_entry_id"] = reversed_entry_id.id
+            invoice_vals["ref"] = ref
+
+        if move_type == "out_invoice" and debit_origin_id:
+            invoice_vals["debit_origin_id"] = debit_origin_id.id
+            invoice_vals["ref"] = ref
+        
+        invoice = self.env["account.move"].create(invoice_vals)
+
+        return invoice
+
+    def test_01_create_invoice(self):
+        """Test the creation and posting of an invoice with foreign currency."""
+        products = [
+            {
+                "product_id": self.product.id,
+                "price_unit": 100,
+                "tax_ids": [(6, 0, [self.tax_iva16.id])],
+            }
+        ]
+        invoice = self._create_invoice(products)
+        invoice.write(
+            {
+                "currency_id": self.currency_usd.id,
+            }
+        )
+        invoice.with_context(move_action_post_alert=True).action_post()
+        self.assertEqual(invoice.state, "posted")
+        _logger.info("test_01_create_invoice --- successfully.")


### PR DESCRIPTION
Problema: Al crear una factura se requiere que se pueda seleccionar cualquier moneda (Y no solo en la moneda base)

Solución: Eliminar la validacion que no permite seleccionar una moneda diferente a la moneda base en facturas.
Se agregaron sus pruebas unitarias

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=55769&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []