### PR TITLE
FEAT #55926: l10n_ve_stock

### DIFF
--- a/l10n_ve_stock/__manifest__.py
+++ b/l10n_ve_stock/__manifest__.py
@@ -7,7 +7,7 @@
     "author": "binaural-dev",
     "website": "https://www.binauraldev.com",
     "category": "Stock",
-    "version": "17.0.0.0.4",
+    "version": "17.0.0.0.5",
     "depends": [
         "stock",
         "l10n_ve_tax",

--- a/l10n_ve_stock/views/products_views.xml
+++ b/l10n_ve_stock/views/products_views.xml
@@ -59,6 +59,10 @@
                     <field name="physical_location_id" options="{'no_create': True}"/>
                 </group>
             </xpath>
+            <xpath expr="//field[@name='taxes_id']" position="attributes">
+                <attribute name="required">1</attribute>
+                
+            </xpath>
         </field>
     </record>
     <record id="product_template_form_view" model="ir.ui.view">


### PR DESCRIPTION
Problema: Para los ambientes homologados no se debe permitir la creación de un producto sin tener asignado un impuesto

Solución: Se agrego el campo de impuesto del cliente como un campo requerido

Tarea (Link): https://binaural.odoo.com/web?db=binaural-dev-binaural-release-10413381&token=4P6sT2NxLGgos2OwxwuG#id=55926&cids=2&menu_id=975&action=341&model=project.task&view_type=form

Tarea de proyecto [x]
Ticket de soporte []